### PR TITLE
Fix manifest

### DIFF
--- a/pkg/sharding/em.yaml
+++ b/pkg/sharding/em.yaml
@@ -24,7 +24,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/event-manager-amd64:main
+        image: projectsveltos/event-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/event-manager.go
+++ b/pkg/sharding/event-manager.go
@@ -42,7 +42,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/event-manager-amd64:main
+        image: projectsveltos/event-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/healthcheck-manager.go
+++ b/pkg/sharding/healthcheck-manager.go
@@ -42,7 +42,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/healthcheck-manager-amd64:main
+        image: projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/hm.yaml
+++ b/pkg/sharding/hm.yaml
@@ -24,7 +24,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/healthcheck-manager-amd64:main
+        image: projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Event-manager and Healthcheck-manager main branches where not updated yet after v0.27.0 release.

This PR fixes shard-controller manifest by rebuilding it