### PR TITLE
Complete unqualified image names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
@@ -280,7 +280,7 @@ undeploy: $(CONTROLLER_GEN) $(KUSTOMIZE) ## Undeploy controller from the K8s clu
 ##
 set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
-	sed -i'' -e 's@image: .*@image: '"${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/default/manager_image_patch.yaml
+	sed -i'' -e 's@image: .*@image: 'docker.io/"${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/default/manager_image_patch.yaml
 
 set-manifest-pull-policy:
 	$(info Updating kustomize pull policy file for manager resource)

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/shard-controller:main
+      - image: docker.io/projectsveltos/shard-controller:dev
         name: manager

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -151,7 +151,7 @@ spec:
         - --report-mode=0
         command:
         - /manager
-        image: projectsveltos/shard-controller:main
+        image: docker.io/projectsveltos/shard-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/ac.yaml
+++ b/pkg/sharding/ac.yaml
@@ -26,7 +26,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/addon-controller.go
+++ b/pkg/sharding/addon-controller.go
@@ -44,7 +44,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/classifier.go
+++ b/pkg/sharding/classifier.go
@@ -41,10 +41,10 @@ spec:
         - --report-mode=0
         - --shard-key={{.SHARD}}
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: projectsveltos/classifier:main
+        image: docker.io/projectsveltos/classifier:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/classifier.yaml
+++ b/pkg/sharding/classifier.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --shard-key={{.SHARD}}
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: projectsveltos/classifier:main
+        image: docker.io/projectsveltos/classifier:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/em.yaml
+++ b/pkg/sharding/em.yaml
@@ -24,7 +24,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/event-manager:main
+        image: docker.io/projectsveltos/event-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/event-manager.go
+++ b/pkg/sharding/event-manager.go
@@ -42,7 +42,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/event-manager:main
+        image: docker.io/projectsveltos/event-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/healthcheck-manager.go
+++ b/pkg/sharding/healthcheck-manager.go
@@ -42,7 +42,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/healthcheck-manager:main
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/hm.yaml
+++ b/pkg/sharding/hm.yaml
@@ -24,7 +24,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/healthcheck-manager:main
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/sc.yaml
+++ b/pkg/sharding/sc.yaml
@@ -24,7 +24,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/sveltoscluster-manager:main
+        image: docker.io/projectsveltos/sveltoscluster-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/sveltoscluster-manager.go
+++ b/pkg/sharding/sveltoscluster-manager.go
@@ -42,7 +42,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/sveltoscluster-manager:main
+        image: docker.io/projectsveltos/sveltoscluster-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Add 'docker.io' registry server name where missing.

That allows applications to run on CRIs not configured to handle unqualified registries.