### PR TITLE
(feat) allow configurable namespace for Sveltos

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,3 +55,16 @@ jobs:
       run: make create-cluster fv
       env:
         FV: true
+  FV-NAMESPACE:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version: 1.26.3
+    - name: fv
+      run: make create-cluster-infra fv-namespace
+      env:
+        FV: true

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.10.0
+TAG ?= main
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
@@ -50,7 +50,7 @@ KUBECTL := $(TOOLS_BIN_DIR)/kubectl
 CLUSTERCTL := $(TOOLS_BIN_DIR)/clusterctl
 
 GOLANGCI_LINT_VERSION := "v2.11.4"
-CLUSTERCTL_VERSION := v1.13.1
+CLUSTERCTL_VERSION := v1.13.2
 
 KUSTOMIZE_VER := v5.8.0
 KUSTOMIZE_BIN := kustomize
@@ -176,18 +176,41 @@ kind-test: test create-cluster fv ## Build docker image; start kind cluster; loa
 fv: $(GINKGO) ## Run Sveltos Controller tests using existing cluster
 	cd test/fv; $(GINKGO) -nodes $(NUM_NODES) --label-filter='FV' --v --trace --randomize-all
 
+.PHONY: kind-test-namespace
+kind-test-namespace: test create-cluster-infra fv-namespace ## Build image; create cluster infra; deploy in random namespace and run fv
+
+.PHONY: fv-namespace
+fv-namespace: $(GINKGO) $(KUBECTL) $(KUSTOMIZE) $(ENVSUBST) ## Deploy Sveltos in a randomly named namespace and run fv
+	$(MAKE) load-image
+	$(MAKE) deploy-crds
+	@SVELTOS_NS="sveltos-$$(openssl rand -hex 4)"; \
+	echo "Deploying in namespace: $$SVELTOS_NS"; \
+	curl -s https://raw.githubusercontent.com/projectsveltos/addon-controller/$(TAG)/manifest/manifest.yaml | \
+	    sed -E 's/^([[:space:]]+)(name|namespace): projectsveltos$$/\1\2: '"$$SVELTOS_NS"'/' | \
+	    $(KUBECTL) apply -f-; \
+	$(KUBECTL) wait --for=condition=Available deployment/addon-controller -n "$$SVELTOS_NS" --timeout=$(TIMEOUT); \
+	$(KUSTOMIZE) build config/default | $(ENVSUBST) | \
+	    sed -E 's/^([[:space:]]+)(name|namespace): projectsveltos$$/\1\2: '"$$SVELTOS_NS"'/' | \
+	    $(KUBECTL) apply -f-; \
+	$(KUBECTL) wait --for=condition=Available deployment/shard-controller -n "$$SVELTOS_NS" --timeout=$(TIMEOUT); \
+	cd test/fv && SVELTOS_NAMESPACE="$$SVELTOS_NS" $(GINKGO) -nodes $(NUM_NODES) --label-filter='FV' --v --trace --randomize-all
+
 .PHONY: test
 test: manifests generate fmt vet $(SETUP_ENVTEST) ## Run uts.
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test $(shell go list ./... |grep -v test/fv |grep -v test/helpers) $(TEST_ARGS) -coverprofile cover.out
 
-.PHONY: create-cluster
-create-cluster: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create a new kind cluster designed for development
+.PHONY: create-cluster-infra
+create-cluster-infra: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create cluster infrastructure without deploying Sveltos
 	$(MAKE) create-control-cluster
 
 	@echo wait for capd-system pod
 	$(KUBECTL) wait --for=condition=Available deployment/capd-controller-manager -n capd-system --timeout=$(TIMEOUT)
-	$(KUBECTL) wait --for=condition=Available deployment/capi-kubeadm-control-plane-controller-manager -n capi-kubeadm-control-plane-system --timeout=$(TIMEOUT)
+
+	@echo wait for capi-kubeadm-bootstrap-system pod
 	$(KUBECTL) wait --for=condition=Available deployment/capi-kubeadm-bootstrap-controller-manager -n capi-kubeadm-bootstrap-system --timeout=$(TIMEOUT)
+
+	@echo wait for capi-kubeadm-control-plane-system pod
+	$(KUBECTL) wait --for=condition=Available deployment/capi-kubeadm-control-plane-controller-manager -n capi-kubeadm-control-plane-system --timeout=$(TIMEOUT)
 
 	@echo "sleep allowing webhook to be ready"
 	sleep 10
@@ -195,8 +218,8 @@ create-cluster: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create a new kin
 	@echo "Create a workload cluster"
 	$(KUBECTL) apply -f $(KIND_CLUSTER_YAML)
 
-	@echo "Start projectsveltos event-manager"
-	$(MAKE) deploy-projectsveltos
+	@echo "wait for cluster to be provisioned"
+	$(KUBECTL) wait cluster $(WORKLOAD_CLUSTER_NAME) -n default --for=jsonpath='{.status.phase}'=Provisioned --timeout=$(TIMEOUT)
 
 	@echo "sleep allowing control plane to be ready"
 	sleep 60
@@ -209,6 +232,11 @@ create-cluster: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create a new kin
 
 	@echo wait for calico pod
 	$(KUBECTL) --kubeconfig=./test/fv/workload_kubeconfig wait --for=condition=Available deployment/calico-kube-controllers -n kube-system --timeout=$(TIMEOUT)
+
+.PHONY: create-cluster
+create-cluster: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create a new kind cluster designed for development
+	$(MAKE) create-cluster-infra
+	$(MAKE) deploy-projectsveltos
 
 .PHONY: delete-cluster
 delete-cluster: $(KIND) ## Deletes the kind cluster $(CONTROL_CLUSTER_NAME)
@@ -301,11 +329,7 @@ create-control-cluster:
 	@echo "Create control cluster with docker as infrastructure provider"
 	CLUSTER_TOPOLOGY=true $(CLUSTERCTL) init --infrastructure docker
 
-deploy-projectsveltos: $(KUSTOMIZE)
-	# Load projectsveltos image into cluster
-	@echo 'Load projectsveltos image into cluster'
-	$(MAKE) load-image
-
+deploy-crds:
 	@echo 'Install libsveltos CRDs'
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/config/crd/bases/lib.projectsveltos.io_accessrequests.yaml
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/config/crd/bases/lib.projectsveltos.io_classifierreports.yaml
@@ -323,6 +347,12 @@ deploy-projectsveltos: $(KUSTOMIZE)
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/config/crd/bases/lib.projectsveltos.io_resourcesummaries.yaml
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/config/crd/bases/lib.projectsveltos.io_rolerequests.yaml
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
+
+deploy-projectsveltos: $(KUSTOMIZE)
+	# Load projectsveltos image into cluster
+	@echo 'Load projectsveltos image into cluster'
+	$(MAKE) load-image
+	$(MAKE) deploy-crds
 
 	@echo "Deploying addon-controller"
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/addon-controller/$(TAG)/manifest/manifest.yaml

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,6 +115,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	sveltosNamespace := getSveltosNamespace()
+	controller.SetSveltosNamespace(sveltosNamespace)
+
 	// Setup the context that's going to be used in controllers and for the manager.
 	ctx := ctrl.SetupSignalHandler()
 
@@ -288,4 +291,13 @@ func getDiagnosticsOptions() metricsserver.Options {
 		SecureServing:  true,
 		FilterProvider: filters.WithAuthenticationAndAuthorization,
 	}
+}
+
+func getSveltosNamespace() string {
+	sveltosNamespace := os.Getenv("NAMESPACE")
+	if sveltosNamespace == "" {
+		setupLog.V(logs.LogInfo).Error(nil, "Missing required environment variables NAMESPACE")
+		os.Exit(1)
+	}
+	return sveltosNamespace
 }

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,3 +15,16 @@ spec:
         - "--v=5"
         - "--report-mode=0"
         - "--agent-in-mgmt-cluster=false"
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/shard-controller:v1.10.0
+      - image: docker.io/projectsveltos/shard-controller:main
         name: manager

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.10.0
+	github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/text v0.37.0
 	k8s.io/api v0.36.1

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/libsveltos v1.10.0 h1:+Gk34qCEOryHMT7xDFSIniiqk3VymhiKs/3EdK5gJ58=
-github.com/projectsveltos/libsveltos v1.10.0/go.mod h1:AzKBiyMTL3KSTLYMii5QdR3ieWyUKBHZCMFWIVCfm6A=
+github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f h1:XrgpnRRH59AwSkSEIcKPUDpAME0Sl4sXLeEhDIaYQMU=
+github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f/go.mod h1:AzKBiyMTL3KSTLYMii5QdR3ieWyUKBHZCMFWIVCfm6A=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/a8m/envsubst v1.4.3
-	github.com/onsi/ginkgo/v2 v2.28.1
+	github.com/onsi/ginkgo/v2 v2.29.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/tools v0.45.0
 	k8s.io/client-go v0.36.1
@@ -39,7 +39,7 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gobuffalo/flect v1.0.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
+	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -96,6 +96,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/vP9vJGqPwcdqsWjOt+V8J7+bTc=
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
+github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 h1:EwtI+Al+DeppwYX2oXJCETMO23COyaKGP6fHVpkpWpg=
+github.com/google/pprof v0.0.0-20260402051712-545e8a4df936/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -134,6 +136,8 @@ github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
+github.com/onsi/ginkgo/v2 v2.29.0 h1:rfh+ZFjgJhYWRoIqVf3Uwx/W20yLrcrE2h2GmYVRaag=
+github.com/onsi/ginkgo/v2 v2.29.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
 github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/internal/controller/controller_suite_test.go
+++ b/internal/controller/controller_suite_test.go
@@ -46,14 +46,14 @@ import (
 const (
 	timeout         = 1 * time.Minute
 	pollingInterval = 5 * time.Second
-	projectsveltoNs = "projectsveltos"
 )
 
 var (
-	testEnv *helpers.TestEnvironment
-	cancel  context.CancelFunc
-	ctx     context.Context
-	scheme  *runtime.Scheme
+	testEnv          *helpers.TestEnvironment
+	cancel           context.CancelFunc
+	ctx              context.Context
+	scheme           *runtime.Scheme
+	sveltosNamespace string
 )
 
 func TestController(t *testing.T) {
@@ -93,11 +93,13 @@ var _ = BeforeSuite(func() {
 	Expect(testEnv.Create(context.TODO(), sveltosCRD)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv, sveltosCRD)).To(Succeed())
 
+	sveltosNamespace = randomString()
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: projectsveltoNs,
+			Name: sveltosNamespace,
 		},
 	}
+	controller.SetSveltosNamespace(sveltosNamespace)
 
 	Expect(testEnv.Create(context.TODO(), namespace)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv.Client, namespace)).To(Succeed())

--- a/internal/controller/management_cluster.go
+++ b/internal/controller/management_cluster.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+var (
+	sveltosNamespace string
+)
+
+func SetSveltosNamespace(ns string) {
+	sveltosNamespace = ns
+}
+
+func getSveltosNamespace() string {
+	return sveltosNamespace
+}

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -291,7 +291,7 @@ func deployControllers(ctx context.Context, c client.Client, shardKey string, //
 			return err
 		}
 	}
-	err = deployDeployment(ctx, c, addonControllerTemplate, shardKey)
+	err = deployDeployment(ctx, c, addonControllerTemplate, getSveltosNamespace(), shardKey)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to create addon-controller deployment %v", err))
 		return err
@@ -305,14 +305,14 @@ func deployControllers(ctx context.Context, c client.Client, shardKey string, //
 			return err
 		}
 	}
-	err = deployDeployment(ctx, c, classifierTemplate, shardKey)
+	err = deployDeployment(ctx, c, classifierTemplate, getSveltosNamespace(), shardKey)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to create classifier deployment %v", err))
 		return err
 	}
 
 	sveltosClusterTemplate := controllerSharding.GetSveltosClusterManagerTemplate()
-	err = deployDeployment(ctx, c, sveltosClusterTemplate, shardKey)
+	err = deployDeployment(ctx, c, sveltosClusterTemplate, getSveltosNamespace(), shardKey)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to create sveltoscluster-manager deployment %v", err))
 		return err
@@ -326,7 +326,7 @@ func deployControllers(ctx context.Context, c client.Client, shardKey string, //
 			return err
 		}
 	}
-	err = deployDeployment(ctx, c, eventManagerTemplate, shardKey)
+	err = deployDeployment(ctx, c, eventManagerTemplate, getSveltosNamespace(), shardKey)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to create event-manager deployment %v", err))
 		return err
@@ -340,7 +340,7 @@ func deployControllers(ctx context.Context, c client.Client, shardKey string, //
 			return err
 		}
 	}
-	err = deployDeployment(ctx, c, healthcheckManagerTemplate, shardKey)
+	err = deployDeployment(ctx, c, healthcheckManagerTemplate, getSveltosNamespace(), shardKey)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to create healthcheck-manager deployment %v", err))
 		return err
@@ -359,35 +359,35 @@ func undeployControllers(ctx context.Context, config *rest.Config, shardKey stri
 	logger.V(logs.LogDebug).Info("undeploy projectsveltos controllers for shard")
 
 	addonControllerTemplate := controllerSharding.GetAddonControllerTemplate()
-	err := undeployDeployment(ctx, config, addonControllerTemplate, shardKey)
+	err := undeployDeployment(ctx, config, addonControllerTemplate, getSveltosNamespace(), shardKey)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to create addon-controller deployment %v", err))
 		return err
 	}
 
 	classifierTemplate := controllerSharding.GetClassifierTemplate()
-	err = undeployDeployment(ctx, config, classifierTemplate, shardKey)
+	err = undeployDeployment(ctx, config, classifierTemplate, getSveltosNamespace(), shardKey)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to create classifier deployment %v", err))
 		return err
 	}
 
 	sveltosClusterTemplate := controllerSharding.GetSveltosClusterManagerTemplate()
-	err = undeployDeployment(ctx, config, sveltosClusterTemplate, shardKey)
+	err = undeployDeployment(ctx, config, sveltosClusterTemplate, getSveltosNamespace(), shardKey)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to create sveltoscluster-manager deployment %v", err))
 		return err
 	}
 
 	eventManagerTemplate := controllerSharding.GetEventManagerTemplate()
-	err = undeployDeployment(ctx, config, eventManagerTemplate, shardKey)
+	err = undeployDeployment(ctx, config, eventManagerTemplate, getSveltosNamespace(), shardKey)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to create event-manager deployment %v", err))
 		return err
 	}
 
 	healthcheckManagerTemplate := controllerSharding.GetHealthCheckManagerTemplate()
-	err = undeployDeployment(ctx, config, healthcheckManagerTemplate, shardKey)
+	err = undeployDeployment(ctx, config, healthcheckManagerTemplate, getSveltosNamespace(), shardKey)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to create healthcheck-manager deployment %v", err))
 		return err
@@ -397,7 +397,7 @@ func undeployControllers(ctx context.Context, config *rest.Config, shardKey stri
 }
 
 func deployDeployment(ctx context.Context, c client.Client,
-	deploymentTemplate []byte, shardKey string) error {
+	deploymentTemplate []byte, sveltosNamespace, shardKey string) error {
 
 	data, err := instantiateTemplate(deploymentTemplate, shardKey)
 	if err != nil {
@@ -408,6 +408,7 @@ func deployDeployment(ctx context.Context, c client.Client,
 	if err != nil {
 		return err
 	}
+	deployment.SetNamespace(sveltosNamespace)
 
 	err = c.Create(ctx, deployment)
 	if err != nil {
@@ -422,7 +423,7 @@ func deployDeployment(ctx context.Context, c client.Client,
 }
 
 func undeployDeployment(ctx context.Context, config *rest.Config,
-	deploymentTemplate []byte, shardKey string) error {
+	deploymentTemplate []byte, sveltosNamespace, shardKey string) error {
 
 	data, err := instantiateTemplate(deploymentTemplate, shardKey)
 	if err != nil {
@@ -433,6 +434,7 @@ func undeployDeployment(ctx context.Context, config *rest.Config,
 	if err != nil {
 		return err
 	}
+	deployment.SetNamespace(sveltosNamespace)
 
 	// Use clientset instead of client. client, even when passing namespace, requires
 	// list permissions at cluster level

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Utils", func() {
 	It("deployDeployment deploys a deployment", func() {
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: randomString(),
+				Name: sveltosNamespace,
 			},
 		}
 
@@ -314,7 +314,8 @@ var _ = Describe("Utils", func() {
 
 		shard := "shard1"
 		nginxDeployment := fmt.Sprintf(nginxDeploymentTemplate, namespace.Name)
-		Expect(controller.DeployDeployment(context.TODO(), c, []byte(nginxDeployment), shard)).To(Succeed())
+		Expect(controller.DeployDeployment(context.TODO(), c, []byte(nginxDeployment),
+			sveltosNamespace, shard)).To(Succeed())
 
 		deploymentList := &appsv1.DeploymentList{}
 		listOptions := []client.ListOption{
@@ -328,7 +329,7 @@ var _ = Describe("Utils", func() {
 	It("deployControllers deploys projectsveltos controllers for a given shard", func() {
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: projectsveltoNs,
+				Name: sveltosNamespace,
 			},
 		}
 
@@ -355,7 +356,7 @@ var _ = Describe("Utils", func() {
 	It("deployControllers deploys projectsveltos controllers passing agent-in-mgmt-cluster option", func() {
 		deploymentList := &appsv1.DeploymentList{}
 		listOptions := []client.ListOption{
-			client.InNamespace(projectsveltoNs),
+			client.InNamespace(sveltosNamespace),
 		}
 
 		Expect(testEnv.List(context.TODO(), deploymentList, listOptions...)).To(Succeed())
@@ -378,7 +379,7 @@ var _ = Describe("Utils", func() {
 
 	It("undeployControllers undeploys projectsveltos controllers for a given shard", func() {
 		listOptions := []client.ListOption{
-			client.InNamespace(projectsveltoNs),
+			client.InNamespace(sveltosNamespace),
 		}
 
 		deploymentList := &appsv1.DeploymentList{}

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -145,7 +145,20 @@ spec:
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/shard-controller:v1.10.0
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/shard-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/ac.yaml
+++ b/pkg/sharding/ac.yaml
@@ -26,7 +26,7 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -39,7 +39,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller@sha256:71e391b8d3f72185462037c13d112e677cf3f61c9e6dc305e61681eba2e88932
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/addon-controller@sha256:01ceda7b6986c59c5ca397b9115e625d9258f79b50d03f0e9d62f8f76a899d9a
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -83,9 +87,21 @@ spec:
         - --shard-key={{.SHARD}}
         - --agent-in-mgmt-cluster=false
         env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/addon-controller@sha256:71e391b8d3f72185462037c13d112e677cf3f61c9e6dc305e61681eba2e88932
+        image: docker.io/projectsveltos/addon-controller@sha256:01ceda7b6986c59c5ca397b9115e625d9258f79b50d03f0e9d62f8f76a899d9a
         name: initialization
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/sharding/addon-controller.go
+++ b/pkg/sharding/addon-controller.go
@@ -44,7 +44,7 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -57,7 +57,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller@sha256:71e391b8d3f72185462037c13d112e677cf3f61c9e6dc305e61681eba2e88932
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/addon-controller@sha256:01ceda7b6986c59c5ca397b9115e625d9258f79b50d03f0e9d62f8f76a899d9a
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -101,9 +105,21 @@ spec:
         - --shard-key={{.SHARD}}
         - --agent-in-mgmt-cluster=false
         env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/addon-controller@sha256:71e391b8d3f72185462037c13d112e677cf3f61c9e6dc305e61681eba2e88932
+        image: docker.io/projectsveltos/addon-controller@sha256:01ceda7b6986c59c5ca397b9115e625d9258f79b50d03f0e9d62f8f76a899d9a
         name: initialization
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/sharding/classifier.go
+++ b/pkg/sharding/classifier.go
@@ -42,12 +42,25 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier@sha256:b690a710e847fad71ab573cdea8872cc1488512f6ca2f375a036e0a33335c0b0
+        env:
+        - name: TOTAL_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/classifier@sha256:e835c4736a93940ee80b0e5e84e02429ed6c8bb01d6eced6854602c571755943
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/classifier.yaml
+++ b/pkg/sharding/classifier.yaml
@@ -24,12 +24,25 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier@sha256:b690a710e847fad71ab573cdea8872cc1488512f6ca2f375a036e0a33335c0b0
+        env:
+        - name: TOTAL_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/classifier@sha256:e835c4736a93940ee80b0e5e84e02429ed6c8bb01d6eced6854602c571755943
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/em.yaml
+++ b/pkg/sharding/em.yaml
@@ -23,11 +23,24 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/event-manager@sha256:772763ae15f0935971fbf0614e21c1800ab89966b77dea6c84dde90778815455
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/event-manager@sha256:9d497594b59abb2831d48d3ae28e60b3ffea34f7fdb3b89c3237e14edcc8effb
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/event-manager.go
+++ b/pkg/sharding/event-manager.go
@@ -41,11 +41,24 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/event-manager@sha256:772763ae15f0935971fbf0614e21c1800ab89966b77dea6c84dde90778815455
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/event-manager@sha256:9d497594b59abb2831d48d3ae28e60b3ffea34f7fdb3b89c3237e14edcc8effb
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/healthcheck-manager.go
+++ b/pkg/sharding/healthcheck-manager.go
@@ -41,11 +41,24 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/healthcheck-manager@sha256:2125ccce8c407ca3a4b98677acc5f856a26606366a3355a6815df05d9c20d4aa
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/healthcheck-manager@sha256:2e2ebcee06134a6a9e45a9b29c7ff76d7d3d0bcf9d9f49fe0e17c803c423af71
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/hm.yaml
+++ b/pkg/sharding/hm.yaml
@@ -23,11 +23,24 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/healthcheck-manager@sha256:2125ccce8c407ca3a4b98677acc5f856a26606366a3355a6815df05d9c20d4aa
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/healthcheck-manager@sha256:2e2ebcee06134a6a9e45a9b29c7ff76d7d3d0bcf9d9f49fe0e17c803c423af71
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/sc.yaml
+++ b/pkg/sharding/sc.yaml
@@ -24,7 +24,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltoscluster-manager@sha256:1588a7e106f34d7f5238c38786c7260f46319297a43d942bc9b0ea6aaeffa0b6
+        image: docker.io/projectsveltos/sveltoscluster-manager:v1.10.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/sharding/sveltoscluster-manager.go
+++ b/pkg/sharding/sveltoscluster-manager.go
@@ -42,7 +42,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltoscluster-manager@sha256:1588a7e106f34d7f5238c38786c7260f46319297a43d942bc9b0ea6aaeffa0b6
+        image: docker.io/projectsveltos/sveltoscluster-manager:v1.10.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/fv/agent_in_mgmt_cluster_test.go
+++ b/test/fv/agent_in_mgmt_cluster_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 const (
-	shardControllerNs     = "projectsveltos"
 	shardControllerName   = "shard-controller"
 	agentInMgmtClusterArg = "--agent-in-mgmt-cluster"
 	kubeRbacProxy         = "kube-rbac-proxy"
@@ -46,7 +45,7 @@ var _ = Describe("Agent in management cluster mode", Serial, func() {
 		shardController := &appsv1.Deployment{}
 
 		Expect(k8sClient.Get(context.TODO(),
-			types.NamespacedName{Namespace: shardControllerNs, Name: shardControllerName},
+			types.NamespacedName{Namespace: sveltosNamespace, Name: shardControllerName},
 			shardController)).To(Succeed())
 
 		for i := range shardController.Spec.Template.Spec.Containers {
@@ -62,7 +61,7 @@ var _ = Describe("Agent in management cluster mode", Serial, func() {
 		shardController := &appsv1.Deployment{}
 
 		Expect(k8sClient.Get(context.TODO(),
-			types.NamespacedName{Namespace: shardControllerNs, Name: shardControllerName},
+			types.NamespacedName{Namespace: sveltosNamespace, Name: shardControllerName},
 			shardController)).To(Succeed())
 
 		updated := false
@@ -100,6 +99,7 @@ var _ = Describe("Agent in management cluster mode", Serial, func() {
 
 		deployment, err := k8s_utils.GetUnstructured(data)
 		Expect(err).To(BeNil())
+		deployment.SetNamespace(sveltosNamespace)
 
 		addonDeployment := &appsv1.Deployment{}
 		Expect(k8sClient.Get(context.TODO(),

--- a/test/fv/fv_suite_test.go
+++ b/test/fv/fv_suite_test.go
@@ -19,6 +19,7 @@ package fv_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -45,6 +46,7 @@ var (
 	k8sClient           client.Client
 	scheme              *runtime.Scheme
 	kindWorkloadCluster *clusterv1.Cluster // This is the name of the kind workload cluster, in the form namespace/name
+	sveltosNamespace    string
 )
 
 const (
@@ -53,6 +55,13 @@ const (
 	key             = "env"
 	value           = "fv"
 )
+
+func init() {
+	sveltosNamespace = os.Getenv("SVELTOS_NAMESPACE")
+	if sveltosNamespace == "" {
+		sveltosNamespace = "projectsveltos"
+	}
+}
 
 func TestFv(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -80,6 +89,8 @@ func TestFv(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	By(fmt.Sprintf("Running with Sveltos namespace: %s", sveltosNamespace))
+
 	restConfig := ctrl.GetConfigOrDie()
 	// To get rid of the annoying request.go log
 	restConfig.QPS = 100

--- a/test/fv/shard_test.go
+++ b/test/fv/shard_test.go
@@ -79,31 +79,32 @@ var _ = Describe("Shard", func() {
 func verifyDeploymentPresence(shardKey string) {
 	By("Verify addon-controller deployment")
 	addonControllerTemplate := controllerSharding.GetAddonControllerTemplate()
-	verifyDeployment(addonControllerTemplate, shardKey)
+	verifyDeployment(addonControllerTemplate, sveltosNamespace, shardKey)
 
 	By("Verify classifier deployment")
 	classifierTemplate := controllerSharding.GetClassifierTemplate()
-	verifyDeployment(classifierTemplate, shardKey)
+	verifyDeployment(classifierTemplate, sveltosNamespace, shardKey)
 
 	By("Verify event-manager deployment")
 	eventManagerTemplate := controllerSharding.GetEventManagerTemplate()
-	verifyDeployment(eventManagerTemplate, shardKey)
+	verifyDeployment(eventManagerTemplate, sveltosNamespace, shardKey)
 
 	By("Verify healtchcheck-manager deployment")
 	healthCheckTemplate := controllerSharding.GetHealthCheckManagerTemplate()
-	verifyDeployment(healthCheckTemplate, shardKey)
+	verifyDeployment(healthCheckTemplate, sveltosNamespace, shardKey)
 
 	By("Verify sveltos-cluster deployment")
 	sveltosClusterTemplate := controllerSharding.GetSveltosClusterManagerTemplate()
-	verifyDeployment(sveltosClusterTemplate, shardKey)
+	verifyDeployment(sveltosClusterTemplate, sveltosNamespace, shardKey)
 }
 
-func verifyDeployment(deplTemplate []byte, shardKey string) {
+func verifyDeployment(deplTemplate []byte, sveltosNamespace, shardKey string) {
 	data, err := instantiateTemplate(deplTemplate, shardKey)
 	Expect(err).To(BeNil())
 
 	deployment, err := k8s_utils.GetUnstructured(data)
 	Expect(err).To(BeNil())
+	deployment.SetNamespace(sveltosNamespace)
 
 	Eventually(func() bool {
 		currentDeployment := &appsv1.Deployment{}


### PR DESCRIPTION
Historically, the Sveltos namespace has been hardcoded/fixed to projectsveltos. This PR is part of series that will remove this limitation.